### PR TITLE
Style website header footer and hero section

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Enqueue Mini Cart AJAX JavaScript
+ */
+function enqueue_mini_cart_ajax_script() {
+    // Only load on pages where cart functionality is needed
+    if (is_woocommerce() || is_cart() || is_checkout() || is_shop() || is_product_category() || is_product_tag() || is_product()) {
+        
+        // Enqueue the mini cart script
+        wp_enqueue_script(
+            'mini-cart-ajax',
+            get_template_directory_uri() . '/js/mini-cart-ajax.js',
+            array('jquery', 'wc-add-to-cart'),
+            '1.0.0',
+            true
+        );
+        
+        // Localize script with AJAX URL and nonce for security
+        wp_localize_script('mini-cart-ajax', 'mini_cart_ajax', array(
+            'ajax_url' => admin_url('admin-ajax.php'),
+            'wc_ajax_url' => WC_AJAX::get_endpoint('%%endpoint%%'),
+            'nonce' => wp_create_nonce('mini_cart_nonce'),
+            'remove_from_cart_url' => wc_get_cart_remove_url(''),
+            'cart_url' => wc_get_cart_url(),
+            'checkout_url' => wc_get_checkout_url(),
+        ));
+    }
+}
+add_action('wp_enqueue_scripts', 'enqueue_mini_cart_ajax_script');
+
+/**
+ * Ensure WooCommerce AJAX add to cart works properly
+ */
+function ensure_woocommerce_ajax_support() {
+    // Enable AJAX add to cart on single product pages
+    add_theme_support('wc-product-gallery-zoom');
+    add_theme_support('wc-product-gallery-lightbox');
+    add_theme_support('wc-product-gallery-slider');
+    
+    // Ensure cart fragments are working
+    if (!is_admin()) {
+        // Force WooCommerce to load cart fragments
+        add_action('wp_enqueue_scripts', function() {
+            if (function_exists('is_woocommerce')) {
+                wp_enqueue_script('wc-cart-fragments');
+            }
+        });
+    }
+}
+add_action('after_setup_theme', 'ensure_woocommerce_ajax_support');
+
+/**
+ * AJAX handler for removing items from cart
+ */
+function ajax_remove_from_cart() {
+    // Verify nonce for security
+    if (!wp_verify_nonce($_POST['security'], 'mini_cart_nonce') && !wp_verify_nonce($_POST['security'], 'wc_cart_nonce')) {
+        wp_die('Security check failed');
+    }
+    
+    $cart_item_key = sanitize_text_field($_POST['cart_item_key']);
+    
+    if ($cart_item_key && WC()->cart) {
+        WC()->cart->remove_cart_item($cart_item_key);
+        
+        // Get updated cart fragments
+        WC_AJAX::get_refreshed_fragments();
+    } else {
+        wp_send_json_error('Invalid cart item key');
+    }
+}
+add_action('wp_ajax_remove_from_cart', 'ajax_remove_from_cart');
+add_action('wp_ajax_nopriv_remove_from_cart', 'ajax_remove_from_cart');
+
+/**
+ * AJAX handler for updating cart item quantity
+ */
+function ajax_update_cart_item() {
+    // Verify nonce
+    if (!wp_verify_nonce($_POST['security'], 'mini_cart_nonce') && !wp_verify_nonce($_POST['security'], 'wc_cart_nonce')) {
+        wp_die('Security check failed');
+    }
+    
+    $cart_item_key = sanitize_text_field($_POST['cart_item_key']);
+    $quantity = intval($_POST['quantity']);
+    
+    if ($cart_item_key && WC()->cart) {
+        if ($quantity <= 0) {
+            WC()->cart->remove_cart_item($cart_item_key);
+        } else {
+            WC()->cart->set_quantity($cart_item_key, $quantity);
+        }
+        
+        // Get updated cart fragments
+        WC_AJAX::get_refreshed_fragments();
+    } else {
+        wp_send_json_error('Invalid cart item key or quantity');
+    }
+}
+add_action('wp_ajax_update_cart_item', 'ajax_update_cart_item');
+add_action('wp_ajax_nopriv_update_cart_item', 'ajax_update_cart_item');
+
+/**
+ * Add cart item key to remove links in mini cart
+ */
+function add_cart_item_key_to_remove_link($sprintf, $cart_item_key, $cart_item) {
+    return sprintf(
+        '<a href="%s" class="remove remove_from_cart_button" aria-label="%s" data-product_id="%s" data-product_sku="%s" data-cart_item_key="%s">&times;</a>',
+        esc_url(wc_get_cart_remove_url($cart_item_key)),
+        esc_attr__('Remove this item', 'woocommerce'),
+        esc_attr($cart_item['product_id']),
+        esc_attr($cart_item['data']->get_sku()),
+        esc_attr($cart_item_key)
+    );
+}
+add_filter('woocommerce_cart_item_remove_link', 'add_cart_item_key_to_remove_link', 10, 3);
+
+/**
+ * Customize mini cart item output to include necessary data attributes
+ */
+function customize_mini_cart_item($cart_item, $cart_item_key, $cart_item_data) {
+    // Add data attributes to cart items for JavaScript functionality
+    echo '<div class="mini-cart-item-data" data-cart-item-key="' . esc_attr($cart_item_key) . '" data-product-id="' . esc_attr($cart_item['product_id']) . '"></div>';
+}
+add_action('woocommerce_mini_cart_item', 'customize_mini_cart_item', 10, 3);
+
+/**
+ * Ensure mini cart updates when items are added via AJAX
+ */
+function refresh_mini_cart_count($fragments) {
+    $cart_count = WC()->cart->get_cart_contents_count();
+    
+    // Add cart count to fragments
+    $fragments['.cart-count'] = '<span class="cart-count">' . $cart_count . '</span>';
+    $fragments['.cart-counter'] = '<span class="cart-counter">' . $cart_count . '</span>';
+    $fragments['.header-cart-count'] = '<span class="header-cart-count">' . $cart_count . '</span>';
+    
+    return $fragments;
+}
+add_filter('woocommerce_add_to_cart_fragments', 'refresh_mini_cart_count');
+
+/**
+ * Add CSS classes for better styling of mini cart
+ */
+function add_mini_cart_css_classes() {
+    ?>
+    <style>
+    .mini_cart_item.removing {
+        opacity: 0.5;
+        pointer-events: none;
+    }
+    
+    .mini_cart_item .remove.removing {
+        opacity: 0.7;
+    }
+    
+    .loading-spinner {
+        animation: spin 1s linear infinite;
+    }
+    
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+    
+    .header-cart-popup {
+        display: none;
+        position: absolute;
+        z-index: 9999;
+    }
+    
+    .header-cart-popup.open {
+        display: block;
+    }
+    </style>
+    <?php
+}
+add_action('wp_head', 'add_mini_cart_css_classes');
+
+/**
+ * Debug function to check if WooCommerce AJAX is working
+ */
+function debug_woocommerce_ajax() {
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('WooCommerce AJAX URL: ' . WC_AJAX::get_endpoint('test'));
+        error_log('Cart fragments enabled: ' . (wp_script_is('wc-cart-fragments', 'enqueued') ? 'Yes' : 'No'));
+    }
+}
+add_action('wp_footer', 'debug_woocommerce_ajax');
+
+/**
+ * Ensure cart session is initialized
+ */
+function ensure_cart_session() {
+    if (is_admin()) return;
+    
+    if (!WC()->session->has_session()) {
+        WC()->session->set_customer_session_cookie(true);
+    }
+}
+add_action('init', 'ensure_cart_session');
+?>

--- a/mini-cart-ajax.js
+++ b/mini-cart-ajax.js
@@ -1,0 +1,218 @@
+/**
+ * Mini Cart AJAX Functionality
+ * Handles product removal and cart updates
+ */
+
+jQuery(document).ready(function($) {
+    
+    // Handle remove item from mini cart
+    $(document).on('click', '.mini_cart_item .remove', function(e) {
+        e.preventDefault();
+        
+        var $removeLink = $(this);
+        var cartItemKey = $removeLink.data('cart_item_key') || $removeLink.attr('data-cart_item_key');
+        
+        // If no cart item key found, try to extract from href
+        if (!cartItemKey) {
+            var href = $removeLink.attr('href');
+            var match = href.match(/remove_item=([^&]+)/);
+            if (match) {
+                cartItemKey = match[1];
+            }
+        }
+        
+        if (!cartItemKey) {
+            console.error('Cart item key not found');
+            return;
+        }
+        
+        // Add loading state
+        $removeLink.addClass('removing');
+        $removeLink.closest('.mini_cart_item').addClass('removing');
+        
+        // AJAX request to remove item
+        $.ajax({
+            url: wc_add_to_cart_params.wc_ajax_url.toString().replace('%%endpoint%%', 'remove_from_cart'),
+            type: 'POST',
+            data: {
+                cart_item_key: cartItemKey,
+                security: wc_add_to_cart_params.wc_ajax_nonce || ''
+            },
+            beforeSend: function() {
+                // Optional: Add loading spinner
+                $removeLink.html('<span class="loading-spinner">×</span>');
+            },
+            success: function(response) {
+                if (response.error) {
+                    console.error('Error removing item:', response.error);
+                    return;
+                }
+                
+                // Update mini cart content
+                updateMiniCart();
+                
+                // Update cart fragments if available
+                if (response.fragments) {
+                    $.each(response.fragments, function(key, value) {
+                        $(key).replaceWith(value);
+                    });
+                }
+                
+                // Trigger cart updated event
+                $(document.body).trigger('wc_fragment_refresh');
+                $(document.body).trigger('cart_item_removed', [cartItemKey]);
+                
+            },
+            error: function(xhr, status, error) {
+                console.error('AJAX error:', error);
+                // Restore original state on error
+                $removeLink.removeClass('removing');
+                $removeLink.closest('.mini_cart_item').removeClass('removing');
+                $removeLink.html('×');
+            }
+        });
+    });
+    
+    // Handle quantity changes in mini cart
+    $(document).on('change', '.mini_cart_item .qty', function() {
+        var $qtyInput = $(this);
+        var cartItemKey = $qtyInput.data('cart_item_key') || $qtyInput.closest('.mini_cart_item').find('.remove').data('cart_item_key');
+        var newQty = $qtyInput.val();
+        
+        if (!cartItemKey) {
+            console.error('Cart item key not found for quantity update');
+            return;
+        }
+        
+        // Update quantity via AJAX
+        $.ajax({
+            url: wc_add_to_cart_params.wc_ajax_url.toString().replace('%%endpoint%%', 'update_cart_item'),
+            type: 'POST',
+            data: {
+                cart_item_key: cartItemKey,
+                quantity: newQty,
+                security: wc_add_to_cart_params.wc_ajax_nonce || ''
+            },
+            success: function(response) {
+                if (response.error) {
+                    console.error('Error updating quantity:', response.error);
+                    return;
+                }
+                
+                // Update mini cart
+                updateMiniCart();
+                
+                // Update fragments
+                if (response.fragments) {
+                    $.each(response.fragments, function(key, value) {
+                        $(key).replaceWith(value);
+                    });
+                }
+                
+                $(document.body).trigger('wc_fragment_refresh');
+            },
+            error: function(xhr, status, error) {
+                console.error('AJAX error updating quantity:', error);
+            }
+        });
+    });
+    
+    // Function to update mini cart content
+    function updateMiniCart() {
+        $.ajax({
+            url: wc_add_to_cart_params.wc_ajax_url.toString().replace('%%endpoint%%', 'get_refreshed_fragments'),
+            type: 'POST',
+            data: {
+                security: wc_add_to_cart_params.wc_ajax_nonce || ''
+            },
+            success: function(response) {
+                if (response && response.fragments) {
+                    $.each(response.fragments, function(key, value) {
+                        $(key).replaceWith(value);
+                    });
+                    
+                    // Update cart count in header if exists
+                    if (response.cart_hash) {
+                        $('.cart-count, .cart-counter, .header-cart-count').html(response.cart_count || '0');
+                    }
+                }
+            },
+            error: function(xhr, status, error) {
+                console.error('Error refreshing mini cart:', error);
+            }
+        });
+    }
+    
+    // Handle mini cart toggle/close
+    $(document).on('click', '.header-cart-toggle, .mini-cart-toggle', function(e) {
+        e.preventDefault();
+        $('.header-cart-popup').toggleClass('open');
+    });
+    
+    // Close mini cart when clicking outside
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.header-cart-popup, .header-cart-toggle, .mini-cart-toggle').length) {
+            $('.header-cart-popup').removeClass('open');
+        }
+    });
+    
+    // Close mini cart with escape key
+    $(document).on('keydown', function(e) {
+        if (e.keyCode === 27) { // Escape key
+            $('.header-cart-popup').removeClass('open');
+        }
+    });
+    
+    // Refresh mini cart on page load
+    $(window).on('load', function() {
+        if (typeof wc_add_to_cart_params !== 'undefined') {
+            updateMiniCart();
+        }
+    });
+    
+    // Listen for cart updates from other parts of the site
+    $(document.body).on('added_to_cart removed_from_cart', function() {
+        updateMiniCart();
+    });
+    
+    // Handle WooCommerce fragment refresh
+    $(document.body).on('wc_fragment_refresh', function() {
+        // Re-initialize any custom functionality after fragment refresh
+        initMiniCartCustomizations();
+    });
+    
+    // Custom mini cart initializations
+    function initMiniCartCustomizations() {
+        // Add any custom styling or functionality here
+        $('.mini_cart_item').each(function() {
+            var $item = $(this);
+            if (!$item.hasClass('initialized')) {
+                $item.addClass('initialized');
+                // Add custom classes or event handlers here
+            }
+        });
+    }
+    
+    // Initialize on document ready
+    initMiniCartCustomizations();
+});
+
+// Fallback for themes that don't properly enqueue WooCommerce scripts
+if (typeof wc_add_to_cart_params === 'undefined') {
+    console.warn('WooCommerce add to cart params not found. Mini cart AJAX may not work properly.');
+    
+    // Basic fallback functionality
+    jQuery(document).ready(function($) {
+        $(document).on('click', '.mini_cart_item .remove', function(e) {
+            e.preventDefault();
+            
+            var $item = $(this).closest('.mini_cart_item');
+            var confirmRemoval = confirm('Are you sure you want to remove this item from your cart?');
+            
+            if (confirmRemoval) {
+                // Fallback: redirect to remove URL
+                window.location.href = $(this).attr('href');
+            }
+        });
+    });
+}

--- a/mini-cart-styles.css
+++ b/mini-cart-styles.css
@@ -1,0 +1,390 @@
+/* Mini Cart Popup Styling - Matching Theme */
+.header-cart-popup {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: #ffffff;
+    border: 1px solid #eaeaea;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    z-index: 9999;
+    min-width: 350px;
+    max-width: 400px;
+    display: none;
+    animation: fadeInUp 0.3s ease-out;
+}
+
+.header-cart-popup.open {
+    display: block;
+}
+
+.header-cart-inner {
+    padding: 1.5rem;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+/* Mini Cart Widget Styling */
+.widget_shopping_cart_content {
+    font-size: 0.875rem;
+    line-height: 1.6;
+}
+
+/* Mini Cart Items */
+.woocommerce-mini-cart {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.woocommerce-mini-cart .mini_cart_item {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem 0;
+    border-bottom: 1px solid #f0f4f8;
+    position: relative;
+    transition: all 0.3s ease;
+}
+
+.woocommerce-mini-cart .mini_cart_item:last-child {
+    border-bottom: none;
+}
+
+.woocommerce-mini-cart .mini_cart_item:hover {
+    background-color: #f9f9f9;
+    margin: 0 -1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    border-radius: 4px;
+}
+
+/* Product Image */
+.woocommerce-mini-cart .mini_cart_item img {
+    width: 60px;
+    height: 60px;
+    object-fit: cover;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+/* Product Details */
+.woocommerce-mini-cart .mini_cart_item .product-details {
+    flex: 1;
+    min-width: 0;
+}
+
+.woocommerce-mini-cart .mini_cart_item a:not(.remove) {
+    color: #345a82;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    display: block;
+    margin-bottom: 0.25rem;
+}
+
+.woocommerce-mini-cart .mini_cart_item a:not(.remove):hover {
+    color: #4d7192;
+}
+
+/* Quantity and Price */
+.woocommerce-mini-cart .quantity {
+    color: #666;
+    font-size: 0.8125rem;
+    margin: 0.25rem 0;
+}
+
+.woocommerce-mini-cart .amount {
+    color: #345a82;
+    font-weight: 600;
+    font-size: 0.875rem;
+}
+
+/* Remove Button */
+.woocommerce-mini-cart .remove {
+    position: absolute;
+    top: 0.5rem;
+    right: 0;
+    width: 24px;
+    height: 24px;
+    background-color: #e74c3c;
+    color: #ffffff !important;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 700;
+    transition: all 0.3s ease;
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.woocommerce-mini-cart .remove:hover {
+    background-color: #c0392b;
+    transform: scale(1.1);
+    box-shadow: 0 4px 8px rgba(231, 76, 60, 0.3);
+}
+
+.woocommerce-mini-cart .remove:active {
+    transform: scale(0.95);
+}
+
+.woocommerce-mini-cart .remove:focus {
+    outline: 2px solid #f1948a;
+    outline-offset: 2px;
+}
+
+/* Loading State */
+.mini_cart_item.removing {
+    opacity: 0.5;
+    pointer-events: none;
+    position: relative;
+}
+
+.mini_cart_item.removing::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 20px;
+    height: 20px;
+    margin: -10px 0 0 -10px;
+    border: 2px solid #4d7192;
+    border-top: 2px solid transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Empty Cart Message */
+.woocommerce-mini-cart__empty-message {
+    text-align: center;
+    color: #666;
+    font-style: italic;
+    padding: 2rem 1rem;
+}
+
+/* Cart Total */
+.woocommerce-mini-cart__total {
+    border-top: 2px solid #f0f4f8;
+    padding-top: 1rem;
+    margin-top: 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+    color: #345a82;
+}
+
+.woocommerce-mini-cart__total .amount {
+    font-size: 1.125rem;
+    color: #345a82;
+}
+
+/* Cart Buttons */
+.woocommerce-mini-cart__buttons {
+    margin-top: 1.5rem;
+    display: flex;
+    gap: 0.75rem;
+    flex-direction: column;
+}
+
+.woocommerce-mini-cart__buttons a {
+    display: block;
+    padding: 0.75rem 1.5rem;
+    text-align: center;
+    text-decoration: none;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    border: 2px solid transparent;
+}
+
+.woocommerce-mini-cart__buttons .button.checkout {
+    background-color: #4d7192;
+    color: #ffffff;
+    border-color: #4d7192;
+}
+
+.woocommerce-mini-cart__buttons .button.checkout:hover {
+    background-color: #6689a2;
+    border-color: #6689a2;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(77, 113, 146, 0.3);
+}
+
+.woocommerce-mini-cart__buttons .button.wc-forward {
+    background-color: transparent;
+    color: #4d7192;
+    border-color: #4d7192;
+}
+
+.woocommerce-mini-cart__buttons .button.wc-forward:hover {
+    background-color: #4d7192;
+    color: #ffffff;
+    transform: translateY(-2px);
+}
+
+/* Cart Toggle Button */
+.header-cart-toggle {
+    position: relative;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    color: #345a82;
+    transition: color 0.3s ease;
+}
+
+.header-cart-toggle:hover {
+    color: #4d7192;
+}
+
+/* Cart Count Badge */
+.cart-count,
+.cart-counter,
+.header-cart-count {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    background-color: #e74c3c;
+    color: #ffffff;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    min-width: 20px;
+}
+
+.cart-count:empty,
+.cart-counter:empty,
+.header-cart-count:empty {
+    display: none;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .header-cart-popup {
+        position: fixed;
+        top: 80px; /* Account for fixed header */
+        left: 1rem;
+        right: 1rem;
+        width: auto;
+        min-width: auto;
+        max-width: none;
+    }
+    
+    .header-cart-inner {
+        max-height: calc(100vh - 200px);
+    }
+    
+    .woocommerce-mini-cart .mini_cart_item {
+        gap: 0.75rem;
+    }
+    
+    .woocommerce-mini-cart .mini_cart_item img {
+        width: 50px;
+        height: 50px;
+    }
+    
+    .woocommerce-mini-cart__buttons {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+}
+
+/* Animation for cart popup */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Accessibility improvements */
+.header-cart-popup:focus-within {
+    outline: 2px solid #345a82;
+    outline-offset: 2px;
+}
+
+/* Custom scrollbar for cart items */
+.header-cart-inner::-webkit-scrollbar {
+    width: 6px;
+}
+
+.header-cart-inner::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 3px;
+}
+
+.header-cart-inner::-webkit-scrollbar-thumb {
+    background: #4d7192;
+    border-radius: 3px;
+}
+
+.header-cart-inner::-webkit-scrollbar-thumb:hover {
+    background: #345a82;
+}
+
+/* Ensure proper z-index layering */
+.header-cart-popup {
+    z-index: 999999;
+}
+
+/* Fix for WooCommerce default styling conflicts */
+.woocommerce .header-cart-popup .button {
+    margin: 0;
+}
+
+.woocommerce .header-cart-popup .amount {
+    color: #345a82;
+}
+
+/* Loading state for entire cart */
+.header-cart-popup.loading {
+    pointer-events: none;
+}
+
+.header-cart-popup.loading::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.8);
+    z-index: 1;
+}
+
+.header-cart-popup.loading::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 30px;
+    height: 30px;
+    margin: -15px 0 0 -15px;
+    border: 3px solid #4d7192;
+    border-top: 3px solid transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    z-index: 2;
+}

--- a/woocommerce-notices.css
+++ b/woocommerce-notices.css
@@ -1,0 +1,218 @@
+/* WooCommerce Notices Styling */
+.woocommerce-notices-wrapper {
+    margin: 20px 0;
+    padding: 0;
+    position: relative;
+    z-index: 100;
+}
+
+.woocommerce-message {
+    background-color: #f7f7f7;
+    border: 1px solid #4d7192;
+    border-left: 4px solid #4d7192;
+    border-radius: 8px;
+    padding: 16px 20px;
+    margin: 0 0 20px 0;
+    color: #345a82;
+    font-size: 14px;
+    line-height: 1.5;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    position: relative;
+    animation: slideInDown 0.4s ease-out;
+}
+
+/* Success/confirmation styling */
+.woocommerce-message::before {
+    content: "✓";
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: #4d7192;
+    color: #ffffff;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 20px;
+    font-size: 12px;
+    font-weight: bold;
+    margin-right: 12px;
+    vertical-align: middle;
+}
+
+/* Continue shopping button styling */
+.woocommerce-message .button.wc-forward {
+    display: inline-block;
+    background-color: #4d7192;
+    color: #ffffff;
+    padding: 8px 16px;
+    border-radius: 6px;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 600;
+    margin-left: 12px;
+    transition: all 0.3s ease;
+    border: 2px solid #4d7192;
+    position: relative;
+    overflow: hidden;
+}
+
+.woocommerce-message .button.wc-forward:hover {
+    background-color: #6689a2;
+    border-color: #6689a2;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(77, 113, 146, 0.3);
+    color: #ffffff;
+}
+
+.woocommerce-message .button.wc-forward:active {
+    background-color: #345a82;
+    border-color: #345a82;
+    transform: translateY(0);
+    box-shadow: 0 2px 4px rgba(52, 90, 130, 0.2);
+}
+
+.woocommerce-message .button.wc-forward:focus {
+    outline: 3px solid #87bdd8;
+    outline-offset: 2px;
+    border-radius: 6px;
+}
+
+/* Error message styling */
+.woocommerce-error {
+    background-color: #fef7f7;
+    border: 1px solid #e74c3c;
+    border-left: 4px solid #e74c3c;
+    border-radius: 8px;
+    padding: 16px 20px;
+    margin: 0 0 20px 0;
+    color: #c0392b;
+    font-size: 14px;
+    line-height: 1.5;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    animation: slideInDown 0.4s ease-out;
+}
+
+.woocommerce-error::before {
+    content: "✕";
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: #e74c3c;
+    color: #ffffff;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 20px;
+    font-size: 12px;
+    font-weight: bold;
+    margin-right: 12px;
+    vertical-align: middle;
+}
+
+/* Info message styling */
+.woocommerce-info {
+    background-color: #f7f9fc;
+    border: 1px solid #7ea0b1;
+    border-left: 4px solid #7ea0b1;
+    border-radius: 8px;
+    padding: 16px 20px;
+    margin: 0 0 20px 0;
+    color: #345a82;
+    font-size: 14px;
+    line-height: 1.5;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    animation: slideInDown 0.4s ease-out;
+}
+
+.woocommerce-info::before {
+    content: "ⓘ";
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: #7ea0b1;
+    color: #ffffff;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 20px;
+    font-size: 12px;
+    font-weight: bold;
+    margin-right: 12px;
+    vertical-align: middle;
+}
+
+/* Animation for notices */
+@keyframes slideInDown {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .woocommerce-notices-wrapper {
+        margin: 15px 0;
+        padding: 0 10px;
+    }
+    
+    .woocommerce-message,
+    .woocommerce-error,
+    .woocommerce-info {
+        padding: 14px 16px;
+        font-size: 13px;
+        margin-bottom: 15px;
+    }
+    
+    .woocommerce-message .button.wc-forward {
+        display: block;
+        margin: 10px 0 0 0;
+        text-align: center;
+        width: 100%;
+        max-width: 200px;
+    }
+    
+    .woocommerce-message::before,
+    .woocommerce-error::before,
+    .woocommerce-info::before {
+        width: 18px;
+        height: 18px;
+        line-height: 18px;
+        font-size: 11px;
+        margin-right: 10px;
+    }
+}
+
+/* Additional styling for multiple notices */
+.woocommerce-notices-wrapper .woocommerce-message + .woocommerce-message,
+.woocommerce-notices-wrapper .woocommerce-error + .woocommerce-error,
+.woocommerce-notices-wrapper .woocommerce-info + .woocommerce-info {
+    margin-top: -10px;
+}
+
+/* Close button for notices (if needed) */
+.woocommerce-notice-dismiss {
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    background: none;
+    border: none;
+    color: #345a82;
+    font-size: 18px;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+    opacity: 0.7;
+    transition: opacity 0.3s ease;
+}
+
+.woocommerce-notice-dismiss:hover {
+    opacity: 1;
+}
+
+.woocommerce-notice-dismiss:focus {
+    outline: 2px solid #345a82;
+    outline-offset: 1px;
+    border-radius: 2px;
+}

--- a/woocommerce-notices.css
+++ b/woocommerce-notices.css
@@ -108,6 +108,12 @@
     align-items: center;
     flex-wrap: wrap;
     gap: 0.5rem;
+    list-style: none; /* Remove default list styling */
+}
+
+/* Error message as list styling */
+.woocommerce-error.woocommerce-error {
+    padding-left: 1.5rem; /* Reset padding for list version */
 }
 
 .woocommerce-error::before {
@@ -125,6 +131,65 @@
     margin-right: 0;
     flex-shrink: 0;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    align-self: flex-start; /* Align icon to top for multi-line content */
+    margin-top: 0.1rem; /* Fine-tune vertical alignment */
+}
+
+/* Error list item styling */
+.woocommerce-error li {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    flex: 1; /* Take remaining space */
+}
+
+/* View cart button in error messages */
+.woocommerce-error .button.wc-forward {
+    display: inline-block;
+    background-color: #e74c3c; /* Error red color */
+    color: #ffffff;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-left: auto;
+    transition: all 0.3s ease;
+    border: 2px solid #e74c3c;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.woocommerce-error .button.wc-forward:hover {
+    background-color: #c0392b; /* Darker red on hover */
+    border-color: #c0392b;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(231, 76, 60, 0.3);
+    color: #ffffff;
+}
+
+.woocommerce-error .button.wc-forward:active {
+    background-color: #a93226; /* Even darker red on active */
+    border-color: #a93226;
+    transform: translateY(0);
+    box-shadow: 0 4px 10px rgba(169, 50, 38, 0.2);
+}
+
+.woocommerce-error .button.wc-forward:focus {
+    outline: 3px solid #f1948a; /* Light red focus outline */
+    outline-offset: 2px;
+    border-radius: 8px;
+}
+
+.woocommerce-error .button.wc-forward:visited {
+    color: #ffffff;
 }
 
 /* Info message styling */
@@ -190,19 +255,29 @@
         margin-bottom: 1rem;
     }
     
-    .woocommerce-message {
+    .woocommerce-message,
+    .woocommerce-error,
+    .woocommerce-info {
         flex-direction: column;
         align-items: flex-start;
         gap: 1rem;
     }
     
-    .woocommerce-message .button.wc-forward {
+    .woocommerce-message .button.wc-forward,
+    .woocommerce-error .button.wc-forward {
         display: block;
         margin: 0;
         margin-left: 0;
         text-align: center;
         width: 100%;
         max-width: 280px; /* Matching hero button max-width */
+    }
+    
+    .woocommerce-error li {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+        width: 100%;
     }
     
     .woocommerce-message::before,

--- a/woocommerce-notices.css
+++ b/woocommerce-notices.css
@@ -1,148 +1,159 @@
-/* WooCommerce Notices Styling */
+/* WooCommerce Notices Styling - Matching Theme */
 .woocommerce-notices-wrapper {
-    margin: 20px 0;
+    margin: 1.5rem 0;
     padding: 0;
     position: relative;
     z-index: 100;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .woocommerce-message {
-    background-color: #f7f7f7;
-    border: 1px solid #4d7192;
-    border-left: 4px solid #4d7192;
+    background-color: #f0f4f8; /* Light background matching trusted platform section */
+    border: 1px solid #4d7192; /* Accent color border */
+    border-left: 5px solid #345a82; /* Primary color left border, matching trusted platform */
     border-radius: 8px;
-    padding: 16px 20px;
-    margin: 0 0 20px 0;
-    color: #345a82;
-    font-size: 14px;
-    line-height: 1.5;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 1rem 1.5rem;
+    margin: 0 0 1.5rem 0;
+    color: #345a82; /* Primary color text */
+    font-size: 0.875rem; /* Matching footer font size */
+    line-height: 1.6; /* Matching hero text line height */
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); /* Matching trusted platform shadow */
     position: relative;
-    animation: slideInDown 0.4s ease-out;
+    animation: fadeInUp 0.8s ease-out forwards; /* Matching hero animation */
 }
 
-/* Success/confirmation styling */
+/* Success/confirmation styling with icon */
 .woocommerce-message::before {
     content: "✓";
     display: inline-block;
-    width: 20px;
-    height: 20px;
-    background-color: #4d7192;
+    width: 24px;
+    height: 24px;
+    background-color: #345a82; /* Primary color */
     color: #ffffff;
     border-radius: 50%;
     text-align: center;
-    line-height: 20px;
-    font-size: 12px;
-    font-weight: bold;
-    margin-right: 12px;
+    line-height: 24px;
+    font-size: 14px;
+    font-weight: 700; /* Matching hero title weight */
+    margin-right: 1rem;
     vertical-align: middle;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Subtle shadow */
 }
 
-/* Continue shopping button styling */
+/* Continue shopping button styling - matching contact button */
 .woocommerce-message .button.wc-forward {
     display: inline-block;
-    background-color: #4d7192;
+    background-color: #4d7192; /* Matching contact button color */
     color: #ffffff;
-    padding: 8px 16px;
-    border-radius: 6px;
+    padding: 0.75rem 1.5rem; /* Matching hero button padding */
+    border-radius: 8px; /* Matching hero button radius */
     text-decoration: none;
-    font-size: 13px;
-    font-weight: 600;
-    margin-left: 12px;
-    transition: all 0.3s ease;
+    font-size: 0.875rem; /* Consistent with footer */
+    font-weight: 600; /* Matching contact button weight */
+    margin-left: 1rem;
+    transition: all 0.3s ease; /* Matching hero button transition */
     border: 2px solid #4d7192;
     position: relative;
     overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); /* Matching logo slider shadow */
 }
 
 .woocommerce-message .button.wc-forward:hover {
-    background-color: #6689a2;
+    background-color: #6689a2; /* Matching contact button hover */
     border-color: #6689a2;
-    transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(77, 113, 146, 0.3);
+    transform: translateY(-2px); /* Matching hero button hover effect */
+    box-shadow: 0 8px 20px rgba(77, 113, 146, 0.3); /* Matching hero button shadow */
     color: #ffffff;
 }
 
 .woocommerce-message .button.wc-forward:active {
-    background-color: #345a82;
+    background-color: #345a82; /* Matching contact button active */
     border-color: #345a82;
     transform: translateY(0);
-    box-shadow: 0 2px 4px rgba(52, 90, 130, 0.2);
+    box-shadow: 0 4px 10px rgba(52, 90, 130, 0.2);
 }
 
 .woocommerce-message .button.wc-forward:focus {
-    outline: 3px solid #87bdd8;
+    outline: 3px solid #87bdd8; /* Matching hero button focus */
     outline-offset: 2px;
-    border-radius: 6px;
+    border-radius: 8px;
+}
+
+.woocommerce-message .button.wc-forward:visited {
+    color: #ffffff; /* Ensuring visited state maintains white text */
 }
 
 /* Error message styling */
 .woocommerce-error {
     background-color: #fef7f7;
     border: 1px solid #e74c3c;
-    border-left: 4px solid #e74c3c;
+    border-left: 5px solid #c0392b; /* Matching border style */
     border-radius: 8px;
-    padding: 16px 20px;
-    margin: 0 0 20px 0;
+    padding: 1rem 1.5rem;
+    margin: 0 0 1.5rem 0;
     color: #c0392b;
-    font-size: 14px;
-    line-height: 1.5;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    animation: slideInDown 0.4s ease-out;
+    font-size: 0.875rem;
+    line-height: 1.6;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    animation: fadeInUp 0.8s ease-out forwards;
 }
 
 .woocommerce-error::before {
     content: "✕";
     display: inline-block;
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
     background-color: #e74c3c;
     color: #ffffff;
     border-radius: 50%;
     text-align: center;
-    line-height: 20px;
-    font-size: 12px;
-    font-weight: bold;
-    margin-right: 12px;
+    line-height: 24px;
+    font-size: 14px;
+    font-weight: 700;
+    margin-right: 1rem;
     vertical-align: middle;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 /* Info message styling */
 .woocommerce-info {
-    background-color: #f7f9fc;
-    border: 1px solid #7ea0b1;
-    border-left: 4px solid #7ea0b1;
+    background-color: #f0f4f8; /* Matching trusted platform background */
+    border: 1px solid #7ea0b1; /* Accent color */
+    border-left: 5px solid #4d7192; /* Secondary accent */
     border-radius: 8px;
-    padding: 16px 20px;
-    margin: 0 0 20px 0;
-    color: #345a82;
-    font-size: 14px;
-    line-height: 1.5;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    animation: slideInDown 0.4s ease-out;
+    padding: 1rem 1.5rem;
+    margin: 0 0 1.5rem 0;
+    color: #345a82; /* Primary color text */
+    font-size: 0.875rem;
+    line-height: 1.6;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    animation: fadeInUp 0.8s ease-out forwards;
 }
 
 .woocommerce-info::before {
     content: "ⓘ";
     display: inline-block;
-    width: 20px;
-    height: 20px;
-    background-color: #7ea0b1;
+    width: 24px;
+    height: 24px;
+    background-color: #4d7192; /* Secondary accent */
     color: #ffffff;
     border-radius: 50%;
     text-align: center;
-    line-height: 20px;
-    font-size: 12px;
-    font-weight: bold;
-    margin-right: 12px;
+    line-height: 24px;
+    font-size: 14px;
+    font-weight: 700;
+    margin-right: 1rem;
     vertical-align: middle;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-/* Animation for notices */
-@keyframes slideInDown {
+/* Animation matching hero section */
+@keyframes fadeInUp {
     from {
         opacity: 0;
-        transform: translateY(-20px);
+        transform: translateY(30px);
     }
     to {
         opacity: 1;
@@ -150,37 +161,37 @@
     }
 }
 
-/* Responsive design */
+/* Responsive design matching theme breakpoints */
 @media (max-width: 768px) {
     .woocommerce-notices-wrapper {
-        margin: 15px 0;
-        padding: 0 10px;
+        margin: 1rem 0;
+        padding: 0 1rem; /* Matching mobile padding */
     }
     
     .woocommerce-message,
     .woocommerce-error,
     .woocommerce-info {
-        padding: 14px 16px;
-        font-size: 13px;
-        margin-bottom: 15px;
+        padding: 1rem;
+        font-size: 0.875rem;
+        margin-bottom: 1rem;
     }
     
     .woocommerce-message .button.wc-forward {
         display: block;
-        margin: 10px 0 0 0;
+        margin: 1rem 0 0 0;
         text-align: center;
         width: 100%;
-        max-width: 200px;
+        max-width: 280px; /* Matching hero button max-width */
     }
     
     .woocommerce-message::before,
     .woocommerce-error::before,
     .woocommerce-info::before {
-        width: 18px;
-        height: 18px;
-        line-height: 18px;
-        font-size: 11px;
-        margin-right: 10px;
+        width: 20px;
+        height: 20px;
+        line-height: 20px;
+        font-size: 12px;
+        margin-right: 0.75rem;
     }
 }
 
@@ -188,30 +199,71 @@
 .woocommerce-notices-wrapper .woocommerce-message + .woocommerce-message,
 .woocommerce-notices-wrapper .woocommerce-error + .woocommerce-error,
 .woocommerce-notices-wrapper .woocommerce-info + .woocommerce-info {
-    margin-top: -10px;
+    margin-top: -0.75rem; /* Slight overlap for multiple notices */
 }
 
-/* Close button for notices (if needed) */
+/* Close button for notices (optional) */
 .woocommerce-notice-dismiss {
     position: absolute;
-    top: 8px;
-    right: 12px;
+    top: 0.75rem;
+    right: 1rem;
     background: none;
     border: none;
-    color: #345a82;
-    font-size: 18px;
+    color: #345a82; /* Primary color */
+    font-size: 1.125rem;
     cursor: pointer;
-    padding: 4px;
+    padding: 0.25rem;
     line-height: 1;
     opacity: 0.7;
     transition: opacity 0.3s ease;
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .woocommerce-notice-dismiss:hover {
     opacity: 1;
+    background-color: rgba(52, 90, 130, 0.1);
 }
 
 .woocommerce-notice-dismiss:focus {
+    outline: 2px solid #345a82;
+    outline-offset: 1px;
+    border-radius: 50%;
+}
+
+/* Integration with site header spacing */
+body.admin-bar .woocommerce-notices-wrapper {
+    margin-top: 2rem; /* Extra spacing when admin bar is present */
+}
+
+/* Ensure notices don't interfere with fixed header */
+.site-header + .woocommerce-notices-wrapper,
+main .woocommerce-notices-wrapper:first-child {
+    margin-top: 1rem;
+}
+
+/* Links within notices matching theme link styling */
+.woocommerce-message a:not(.button),
+.woocommerce-error a:not(.button),
+.woocommerce-info a:not(.button) {
+    color: #345a82; /* Primary color */
+    text-decoration: underline;
+    transition: color 0.3s ease;
+}
+
+.woocommerce-message a:not(.button):hover,
+.woocommerce-error a:not(.button):hover,
+.woocommerce-info a:not(.button):hover {
+    color: #4d7192; /* Hover color matching theme */
+}
+
+.woocommerce-message a:not(.button):focus,
+.woocommerce-error a:not(.button):focus,
+.woocommerce-info a:not(.button):focus {
     outline: 2px solid #345a82;
     outline-offset: 1px;
     border-radius: 2px;

--- a/woocommerce-notices.css
+++ b/woocommerce-notices.css
@@ -22,23 +22,27 @@
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); /* Matching trusted platform shadow */
     position: relative;
     animation: fadeInUp 0.8s ease-out forwards; /* Matching hero animation */
+    display: flex;
+    align-items: center; /* Align icon, text, and button vertically */
+    flex-wrap: wrap;
+    gap: 0.5rem; /* Add consistent spacing between elements */
 }
 
 /* Success/confirmation styling with icon */
 .woocommerce-message::before {
     content: "✓";
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 24px;
     height: 24px;
     background-color: #345a82; /* Primary color */
     color: #ffffff;
     border-radius: 50%;
-    text-align: center;
-    line-height: 24px;
     font-size: 14px;
     font-weight: 700; /* Matching hero title weight */
-    margin-right: 1rem;
-    vertical-align: middle;
+    margin-right: 0; /* Remove margin as gap handles spacing */
+    flex-shrink: 0; /* Prevent icon from shrinking */
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Subtle shadow */
 }
 
@@ -52,12 +56,14 @@
     text-decoration: none;
     font-size: 0.875rem; /* Consistent with footer */
     font-weight: 600; /* Matching contact button weight */
-    margin-left: 1rem;
+    margin-left: auto; /* Push button to the right */
     transition: all 0.3s ease; /* Matching hero button transition */
     border: 2px solid #4d7192;
     position: relative;
     overflow: hidden;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); /* Matching logo slider shadow */
+    flex-shrink: 0; /* Prevent button from shrinking */
+    white-space: nowrap; /* Prevent button text from wrapping */
 }
 
 .woocommerce-message .button.wc-forward:hover {
@@ -98,22 +104,26 @@
     line-height: 1.6;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     animation: fadeInUp 0.8s ease-out forwards;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .woocommerce-error::before {
     content: "✕";
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 24px;
     height: 24px;
     background-color: #e74c3c;
     color: #ffffff;
     border-radius: 50%;
-    text-align: center;
-    line-height: 24px;
     font-size: 14px;
     font-weight: 700;
-    margin-right: 1rem;
-    vertical-align: middle;
+    margin-right: 0;
+    flex-shrink: 0;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -130,22 +140,26 @@
     line-height: 1.6;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     animation: fadeInUp 0.8s ease-out forwards;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .woocommerce-info::before {
     content: "ⓘ";
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 24px;
     height: 24px;
     background-color: #4d7192; /* Secondary accent */
     color: #ffffff;
     border-radius: 50%;
-    text-align: center;
-    line-height: 24px;
     font-size: 14px;
     font-weight: 700;
-    margin-right: 1rem;
-    vertical-align: middle;
+    margin-right: 0;
+    flex-shrink: 0;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -176,9 +190,16 @@
         margin-bottom: 1rem;
     }
     
+    .woocommerce-message {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+    
     .woocommerce-message .button.wc-forward {
         display: block;
-        margin: 1rem 0 0 0;
+        margin: 0;
+        margin-left: 0;
         text-align: center;
         width: 100%;
         max-width: 280px; /* Matching hero button max-width */
@@ -189,9 +210,8 @@
     .woocommerce-info::before {
         width: 20px;
         height: 20px;
-        line-height: 20px;
         font-size: 12px;
-        margin-right: 0.75rem;
+        margin-right: 0;
     }
 }
 


### PR DESCRIPTION
Add styling for WooCommerce notices (success, error, info) to seamlessly integrate with the existing theme's design.

---
<a href="https://cursor.com/background-agent?bcId=bc-0aaba106-50c9-4a03-9721-507233931235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0aaba106-50c9-4a03-9721-507233931235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

