### PR TITLE
Build wordpress slider with custom css

### DIFF
--- a/cryptotax-theme/README.md
+++ b/cryptotax-theme/README.md
@@ -1,0 +1,179 @@
+# CryptoTax WordPress Theme
+
+A custom WordPress theme featuring a beautiful slider component with CryptoTax brand colors and modern design.
+
+## Features
+
+- **Custom Slider Block**: Gutenberg-compatible slider block with your brand colors
+- **Responsive Design**: Works perfectly on all devices
+- **Brand Colors**: Uses your CryptoTax color palette (#0043FF, #A370F1, #4BF2E6, etc.)
+- **Smooth Animations**: Beautiful transitions and effects
+- **Accessibility**: Keyboard navigation and ARIA support
+- **Touch Support**: Swipe gestures on mobile devices
+- **Autoplay Options**: Configurable autoplay with custom speeds
+- **Navigation Controls**: Dots and arrow navigation
+
+## Installation
+
+1. **Upload Theme**: Upload the `cryptotax-theme` folder to your `/wp-content/themes/` directory
+2. **Activate Theme**: Go to WordPress Admin > Appearance > Themes and activate "CryptoTax Theme"
+3. **Ensure jQuery**: The theme requires jQuery (included with WordPress by default)
+
+## Usage
+
+### Method 1: Gutenberg Block Editor
+
+1. Edit any page or post in the block editor
+2. Add a new block and search for "CryptoTax Slider"
+3. Configure your slides in the block settings:
+   - Upload images
+   - Add titles and descriptions
+   - Set button text and URLs
+   - Configure autoplay, navigation, and timing
+
+### Method 2: Shortcode
+
+Add the slider anywhere using the shortcode:
+
+```php
+[cryptotax_slider]
+```
+
+With custom options:
+```php
+[cryptotax_slider autoplay="true" autoplay_speed="6000" show_dots="true" show_arrows="true"]
+```
+
+### Method 3: PHP Function
+
+In your theme files:
+
+```php
+<?php
+echo cryptotax_render_slider_block(array(
+    'slides' => array(
+        array(
+            'image' => 'https://your-image-url.jpg',
+            'title' => 'Your Title',
+            'description' => 'Your description',
+            'buttonText' => 'Button Text',
+            'buttonUrl' => '#your-link'
+        )
+    ),
+    'autoplay' => true,
+    'autoplaySpeed' => 5000,
+    'showDots' => true,
+    'showArrows' => true
+));
+?>
+```
+
+## Customization
+
+### Colors
+
+The theme uses CSS custom properties for easy color customization. Edit `assets/css/cryptotax-color-palette.css`:
+
+```css
+:root {
+  --cryptotax-deep-blue: #0043FF;
+  --cryptotax-purple: #A370F1;
+  --cryptotax-cyan: #4BF2E6;
+  --cryptotax-bright-blue: #0065FF;
+  /* ... more colors */
+}
+```
+
+### Slider Styles
+
+Customize slider appearance in `assets/css/slider.css`. Key classes:
+
+- `.cryptotax-slider-container`: Main container
+- `.cryptotax-slide`: Individual slides
+- `.slide-content`: Content wrapper
+- `.slide-title`: Slide titles
+- `.slide-description`: Slide descriptions
+- `.slide-button`: Call-to-action buttons
+
+### JavaScript Customization
+
+Extend slider functionality in `assets/js/slider.js`. The slider exposes these events:
+
+```javascript
+$('#your-slider').on('slideChanged', function(e, data) {
+    console.log('Current slide:', data.currentSlide);
+});
+```
+
+## File Structure
+
+```
+cryptotax-theme/
+├── assets/
+│   ├── css/
+│   │   ├── cryptotax-color-palette.css
+│   │   ├── slider.css
+│   │   └── blocks-editor.css
+│   └── js/
+│       ├── slider.js
+│       └── blocks.js
+├── blocks/
+│   └── slider/
+├── inc/
+├── style.css
+├── functions.php
+├── index.php
+├── front-page.php
+├── demo.html
+└── README.md
+```
+
+## Demo
+
+Open `demo.html` in your browser to see the slider in action with all features demonstrated.
+
+## Browser Support
+
+- Chrome 60+
+- Firefox 60+
+- Safari 12+
+- Edge 79+
+- Mobile browsers (iOS Safari, Chrome Mobile)
+
+## Requirements
+
+- WordPress 5.0+
+- PHP 7.4+
+- jQuery (included with WordPress)
+
+## Configuration Options
+
+### Block/Shortcode Attributes
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `slides` | Array | Default slide | Array of slide objects |
+| `autoplay` | Boolean | `true` | Enable/disable autoplay |
+| `autoplaySpeed` | Number | `5000` | Autoplay speed in milliseconds |
+| `showDots` | Boolean | `true` | Show navigation dots |
+| `showArrows` | Boolean | `true` | Show navigation arrows |
+
+### Slide Object Structure
+
+```javascript
+{
+    image: 'https://image-url.jpg',
+    title: 'Slide Title',
+    description: 'Slide description text',
+    buttonText: 'Button Text',
+    buttonUrl: '#link-url'
+}
+```
+
+## Support
+
+For support and customization requests, please contact the CryptoTax development team.
+
+## License
+
+This theme is proprietary to CryptoTax. All rights reserved.

--- a/cryptotax-theme/assets/css/blocks-editor.css
+++ b/cryptotax-theme/assets/css/blocks-editor.css
@@ -1,0 +1,145 @@
+/* Block Editor Styles for CryptoTax Slider */
+
+.wp-block-cryptotax-slider {
+  margin: 1rem 0;
+}
+
+/* Editor Preview Styles */
+.cryptotax-slider-editor {
+  border: 2px dashed #ddd;
+  padding: 2rem;
+  text-align: center;
+  background: #f9f9f9;
+  border-radius: 8px;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.cryptotax-slider-editor h3 {
+  color: var(--cryptotax-deep-blue);
+  margin-bottom: 1rem;
+}
+
+.cryptotax-slider-editor p {
+  color: var(--cryptotax-medium-gray);
+  margin-bottom: 1rem;
+}
+
+/* Inspector Controls Styles */
+.cryptotax-slider-inspector {
+  padding: 1rem;
+}
+
+.cryptotax-slider-inspector .components-panel__body {
+  border-top: 1px solid #e2e4e7;
+}
+
+.cryptotax-slider-inspector .components-base-control {
+  margin-bottom: 1rem;
+}
+
+/* Slide Item Editor */
+.cryptotax-slide-editor {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: white;
+}
+
+.cryptotax-slide-editor .components-base-control {
+  margin-bottom: 0.75rem;
+}
+
+.cryptotax-slide-editor .components-button {
+  margin-top: 0.5rem;
+}
+
+/* Add Slide Button */
+.cryptotax-add-slide {
+  width: 100%;
+  padding: 1rem;
+  border: 2px dashed var(--cryptotax-deep-blue);
+  background: transparent;
+  color: var(--cryptotax-deep-blue);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.cryptotax-add-slide:hover {
+  background: var(--cryptotax-deep-blue);
+  color: white;
+}
+
+/* Media Upload Button */
+.cryptotax-media-upload {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100px;
+  border: 2px dashed #ddd;
+  border-radius: 4px;
+  background: #f9f9f9;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.cryptotax-media-upload:hover {
+  border-color: var(--cryptotax-deep-blue);
+  background: rgba(0, 67, 255, 0.05);
+}
+
+.cryptotax-media-upload img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+/* Toggle Controls */
+.cryptotax-toggle-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+}
+
+/* Range Controls */
+.cryptotax-range-control {
+  margin: 1rem 0;
+}
+
+.cryptotax-range-control .components-range-control__wrapper {
+  margin-left: 0;
+}
+
+/* Color Palette */
+.cryptotax-color-palette {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.cryptotax-color-item {
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: all 0.3s ease;
+}
+
+.cryptotax-color-item:hover,
+.cryptotax-color-item.active {
+  border-color: #333;
+  transform: scale(1.1);
+}
+
+.cryptotax-color-item.deep-blue { background: #0043FF; }
+.cryptotax-color-item.purple { background: #A370F1; }
+.cryptotax-color-item.cyan { background: #4BF2E6; }
+.cryptotax-color-item.bright-blue { background: #0065FF; }

--- a/cryptotax-theme/assets/css/cryptotax-color-palette.css
+++ b/cryptotax-theme/assets/css/cryptotax-color-palette.css
@@ -1,0 +1,22 @@
+/* CryptoTax Color Palette */
+:root {
+  /* Primary Brand Colors */
+  --cryptotax-deep-blue: #0043FF;
+  --cryptotax-purple: #A370F1;
+  --cryptotax-cyan: #4BF2E6;
+  --cryptotax-bright-blue: #0065FF;
+  
+  /* Neutral Colors */
+  --cryptotax-light-gray: #EEEEEE;
+  --cryptotax-medium-gray: #777777;
+  --cryptotax-dark-gray: #333333;
+  --cryptotax-white: #FFFFFF;
+  
+  /* Gradient Combinations */
+  --cryptotax-primary-gradient: linear-gradient(135deg, #0043FF 0%, #A370F1 100%);
+  --cryptotax-secondary-gradient: linear-gradient(135deg, #4BF2E6 0%, #0065FF 100%);
+  
+  /* Shadow and Effects */
+  --cryptotax-shadow: 0 4px 15px rgba(0, 67, 255, 0.1);
+  --cryptotax-shadow-hover: 0 8px 25px rgba(0, 67, 255, 0.2);
+}

--- a/cryptotax-theme/assets/css/slider.css
+++ b/cryptotax-theme/assets/css/slider.css
@@ -1,0 +1,305 @@
+/* CryptoTax Slider Styles */
+
+.cryptotax-slider-container {
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: var(--cryptotax-shadow);
+  background: var(--cryptotax-dark-gray);
+}
+
+.cryptotax-slider {
+  position: relative;
+  width: 100%;
+  height: 500px;
+  min-height: 400px;
+}
+
+@media (max-width: 768px) {
+  .cryptotax-slider {
+    height: 350px;
+    min-height: 300px;
+  }
+}
+
+.cryptotax-slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity 0.8s ease-in-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cryptotax-slide.active {
+  opacity: 1;
+}
+
+.slide-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  z-index: 1;
+}
+
+.slide-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, rgba(0, 67, 255, 0.7) 0%, rgba(163, 112, 241, 0.7) 100%);
+  z-index: 2;
+}
+
+.slide-content {
+  position: relative;
+  z-index: 3;
+  text-align: center;
+  color: var(--cryptotax-white);
+  padding: 2rem;
+  max-width: 800px;
+  width: 100%;
+}
+
+.slide-content-inner {
+  animation: slideInUp 0.8s ease-out;
+}
+
+.slide-title {
+  font-size: 3rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  line-height: 1.2;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+@media (max-width: 768px) {
+  .slide-title {
+    font-size: 2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .slide-title {
+    font-size: 1.5rem;
+  }
+}
+
+.slide-description {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+  opacity: 0.95;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+@media (max-width: 768px) {
+  .slide-description {
+    font-size: 1.1rem;
+    margin-bottom: 1.5rem;
+  }
+}
+
+.slide-button {
+  display: inline-block;
+  padding: 1rem 2rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 50px;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 15px rgba(0, 67, 255, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.slide-button:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--cryptotax-shadow-hover);
+  background: var(--cryptotax-secondary-gradient) !important;
+  color: var(--cryptotax-white) !important;
+}
+
+/* Slider Navigation Arrows */
+.slider-arrows {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  z-index: 4;
+  pointer-events: none;
+}
+
+.slider-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: all;
+  backdrop-filter: blur(10px);
+  color: var(--cryptotax-white);
+}
+
+.slider-arrow:hover {
+  background: rgba(0, 67, 255, 0.8);
+  transform: translateY(-50%) scale(1.1);
+}
+
+.slider-prev {
+  left: 2rem;
+}
+
+.slider-next {
+  right: 2rem;
+}
+
+@media (max-width: 768px) {
+  .slider-arrow {
+    width: 40px;
+    height: 40px;
+  }
+  
+  .slider-prev {
+    left: 1rem;
+  }
+  
+  .slider-next {
+    right: 1rem;
+  }
+}
+
+/* Slider Dots */
+.slider-dots {
+  position: absolute;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.75rem;
+  z-index: 4;
+}
+
+.slider-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.slider-dot.active,
+.slider-dot:hover {
+  background: var(--cryptotax-cyan);
+  border-color: var(--cryptotax-cyan);
+  transform: scale(1.2);
+}
+
+/* Animations */
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Loading state */
+.cryptotax-slider-container.loading {
+  background: var(--cryptotax-primary-gradient);
+}
+
+.cryptotax-slider-container.loading::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  border-top: 3px solid var(--cryptotax-white);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  z-index: 5;
+}
+
+@keyframes spin {
+  0% { transform: translate(-50%, -50%) rotate(0deg); }
+  100% { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+/* Block Editor Specific Styles */
+.wp-block-cryptotax-slider {
+  margin: 2rem 0;
+}
+
+/* Responsive Design */
+@media (max-width: 1024px) {
+  .slide-content {
+    padding: 1.5rem;
+  }
+  
+  .slide-title {
+    font-size: 2.5rem;
+  }
+  
+  .slide-description {
+    font-size: 1.15rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .cryptotax-slider {
+    height: 300px;
+    min-height: 250px;
+  }
+  
+  .slide-content {
+    padding: 1rem;
+  }
+  
+  .slide-button {
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+  }
+  
+  .slider-dots {
+    bottom: 1rem;
+  }
+}

--- a/cryptotax-theme/assets/js/blocks.js
+++ b/cryptotax-theme/assets/js/blocks.js
@@ -1,0 +1,285 @@
+/**
+ * CryptoTax Slider Block for Gutenberg Editor
+ */
+
+(function(wp) {
+    'use strict';
+
+    const { registerBlockType } = wp.blocks;
+    const { InspectorControls, MediaUpload, MediaUploadCheck } = wp.blockEditor;
+    const { 
+        PanelBody, 
+        Button, 
+        ToggleControl, 
+        RangeControl, 
+        TextControl, 
+        TextareaControl,
+        Card,
+        CardBody,
+        CardHeader
+    } = wp.components;
+    const { useState, useEffect } = wp.element;
+    const { __ } = wp.i18n;
+
+    // Default slide data
+    const defaultSlide = {
+        image: 'https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1',
+        title: 'Welcome to CryptoTax',
+        description: 'Professional cryptocurrency tax solutions',
+        buttonText: 'Get Started',
+        buttonUrl: '#'
+    };
+
+    registerBlockType('cryptotax/slider', {
+        title: __('CryptoTax Slider', 'cryptotax'),
+        description: __('A beautiful, responsive slider with CryptoTax branding', 'cryptotax'),
+        icon: 'slides',
+        category: 'cryptotax',
+        keywords: [
+            __('slider', 'cryptotax'),
+            __('carousel', 'cryptotax'),
+            __('cryptotax', 'cryptotax'),
+        ],
+        attributes: {
+            slides: {
+                type: 'array',
+                default: [defaultSlide]
+            },
+            autoplay: {
+                type: 'boolean',
+                default: true
+            },
+            autoplaySpeed: {
+                type: 'number',
+                default: 5000
+            },
+            showDots: {
+                type: 'boolean',
+                default: true
+            },
+            showArrows: {
+                type: 'boolean',
+                default: true
+            }
+        },
+        supports: {
+            align: ['wide', 'full'],
+            html: false,
+        },
+
+        edit: function(props) {
+            const { attributes, setAttributes } = props;
+            const { slides, autoplay, autoplaySpeed, showDots, showArrows } = attributes;
+
+            // Add a new slide
+            const addSlide = () => {
+                const newSlides = [...slides, { ...defaultSlide }];
+                setAttributes({ slides: newSlides });
+            };
+
+            // Remove a slide
+            const removeSlide = (index) => {
+                if (slides.length > 1) {
+                    const newSlides = slides.filter((_, i) => i !== index);
+                    setAttributes({ slides: newSlides });
+                }
+            };
+
+            // Update slide data
+            const updateSlide = (index, key, value) => {
+                const newSlides = [...slides];
+                newSlides[index][key] = value;
+                setAttributes({ slides: newSlides });
+            };
+
+            // Render slide editor
+            const renderSlideEditor = (slide, index) => {
+                return wp.element.createElement(
+                    Card,
+                    { key: index, className: 'cryptotax-slide-editor' },
+                    wp.element.createElement(
+                        CardHeader,
+                        null,
+                        wp.element.createElement(
+                            'div',
+                            { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' } },
+                            wp.element.createElement('strong', null, `Slide ${index + 1}`),
+                            slides.length > 1 && wp.element.createElement(
+                                Button,
+                                {
+                                    isDestructive: true,
+                                    isSmall: true,
+                                    onClick: () => removeSlide(index)
+                                },
+                                __('Remove', 'cryptotax')
+                            )
+                        )
+                    ),
+                    wp.element.createElement(
+                        CardBody,
+                        null,
+                        // Image Upload
+                        wp.element.createElement(
+                            MediaUploadCheck,
+                            null,
+                            wp.element.createElement(
+                                MediaUpload,
+                                {
+                                    onSelect: (media) => updateSlide(index, 'image', media.url),
+                                    allowedTypes: ['image'],
+                                    value: slide.image,
+                                    render: ({ open }) => wp.element.createElement(
+                                        'div',
+                                        { className: 'cryptotax-media-upload', onClick: open },
+                                        slide.image 
+                                            ? wp.element.createElement('img', { src: slide.image, alt: slide.title })
+                                            : wp.element.createElement('div', null, __('Click to select image', 'cryptotax'))
+                                    )
+                                }
+                            )
+                        ),
+                        // Title
+                        wp.element.createElement(
+                            TextControl,
+                            {
+                                label: __('Title', 'cryptotax'),
+                                value: slide.title,
+                                onChange: (value) => updateSlide(index, 'title', value),
+                                placeholder: __('Enter slide title...', 'cryptotax')
+                            }
+                        ),
+                        // Description
+                        wp.element.createElement(
+                            TextareaControl,
+                            {
+                                label: __('Description', 'cryptotax'),
+                                value: slide.description,
+                                onChange: (value) => updateSlide(index, 'description', value),
+                                placeholder: __('Enter slide description...', 'cryptotax')
+                            }
+                        ),
+                        // Button Text
+                        wp.element.createElement(
+                            TextControl,
+                            {
+                                label: __('Button Text', 'cryptotax'),
+                                value: slide.buttonText,
+                                onChange: (value) => updateSlide(index, 'buttonText', value),
+                                placeholder: __('Enter button text...', 'cryptotax')
+                            }
+                        ),
+                        // Button URL
+                        wp.element.createElement(
+                            TextControl,
+                            {
+                                label: __('Button URL', 'cryptotax'),
+                                value: slide.buttonUrl,
+                                onChange: (value) => updateSlide(index, 'buttonUrl', value),
+                                placeholder: __('Enter button URL...', 'cryptotax')
+                            }
+                        )
+                    )
+                );
+            };
+
+            return [
+                // Inspector Controls
+                wp.element.createElement(
+                    InspectorControls,
+                    { key: 'inspector' },
+                    wp.element.createElement(
+                        PanelBody,
+                        { title: __('Slider Settings', 'cryptotax'), initialOpen: true },
+                        wp.element.createElement(
+                            ToggleControl,
+                            {
+                                label: __('Autoplay', 'cryptotax'),
+                                checked: autoplay,
+                                onChange: (value) => setAttributes({ autoplay: value })
+                            }
+                        ),
+                        autoplay && wp.element.createElement(
+                            RangeControl,
+                            {
+                                label: __('Autoplay Speed (ms)', 'cryptotax'),
+                                value: autoplaySpeed,
+                                onChange: (value) => setAttributes({ autoplaySpeed: value }),
+                                min: 1000,
+                                max: 10000,
+                                step: 500
+                            }
+                        ),
+                        wp.element.createElement(
+                            ToggleControl,
+                            {
+                                label: __('Show Navigation Dots', 'cryptotax'),
+                                checked: showDots,
+                                onChange: (value) => setAttributes({ showDots: value })
+                            }
+                        ),
+                        wp.element.createElement(
+                            ToggleControl,
+                            {
+                                label: __('Show Navigation Arrows', 'cryptotax'),
+                                checked: showArrows,
+                                onChange: (value) => setAttributes({ showArrows: value })
+                            }
+                        )
+                    )
+                ),
+                // Block Editor Content
+                wp.element.createElement(
+                    'div',
+                    { key: 'editor', className: 'cryptotax-slider-inspector' },
+                    wp.element.createElement(
+                        'h3',
+                        { style: { marginBottom: '1rem', color: '#0043FF' } },
+                        __('CryptoTax Slider', 'cryptotax')
+                    ),
+                    wp.element.createElement(
+                        'p',
+                        { style: { marginBottom: '1.5rem', color: '#777' } },
+                        __('Configure your slides below. The slider will be displayed on the frontend.', 'cryptotax')
+                    ),
+                    // Render slide editors
+                    slides.map((slide, index) => renderSlideEditor(slide, index)),
+                    // Add Slide Button
+                    wp.element.createElement(
+                        Button,
+                        {
+                            isPrimary: true,
+                            onClick: addSlide,
+                            className: 'cryptotax-add-slide',
+                            style: { marginTop: '1rem', width: '100%' }
+                        },
+                        __('+ Add Slide', 'cryptotax')
+                    ),
+                    // Preview Notice
+                    wp.element.createElement(
+                        'div',
+                        { 
+                            style: { 
+                                marginTop: '1.5rem', 
+                                padding: '1rem', 
+                                background: '#f0f8ff', 
+                                border: '1px solid #0043FF', 
+                                borderRadius: '4px' 
+                            } 
+                        },
+                        wp.element.createElement(
+                            'p',
+                            { style: { margin: 0, color: '#0043FF', fontWeight: 'bold' } },
+                            __('Preview: The slider will be fully functional on the frontend with animations, navigation, and autoplay.', 'cryptotax')
+                        )
+                    )
+                )
+            ];
+        },
+
+        save: function() {
+            // Server-side rendering
+            return null;
+        }
+    });
+
+})(window.wp);

--- a/cryptotax-theme/assets/js/slider.js
+++ b/cryptotax-theme/assets/js/slider.js
@@ -1,0 +1,276 @@
+/**
+ * CryptoTax Slider JavaScript
+ */
+
+(function($) {
+    'use strict';
+
+    class CryptoTaxSlider {
+        constructor(container) {
+            this.container = $(container);
+            this.slider = this.container.find('.cryptotax-slider');
+            this.slides = this.container.find('.cryptotax-slide');
+            this.dots = this.container.find('.slider-dot');
+            this.prevBtn = this.container.find('.slider-prev');
+            this.nextBtn = this.container.find('.slider-next');
+            
+            this.currentSlide = 0;
+            this.totalSlides = this.slides.length;
+            this.autoplay = this.container.data('autoplay') === true;
+            this.autoplaySpeed = this.container.data('autoplay-speed') || 5000;
+            this.autoplayTimer = null;
+            this.isTransitioning = false;
+            
+            this.init();
+        }
+
+        init() {
+            if (this.totalSlides <= 1) {
+                return;
+            }
+
+            this.bindEvents();
+            
+            if (this.autoplay) {
+                this.startAutoplay();
+            }
+
+            // Add keyboard navigation
+            this.container.attr('tabindex', '0');
+            this.bindKeyboardEvents();
+
+            // Add touch/swipe support
+            this.bindTouchEvents();
+
+            // Initialize ARIA attributes
+            this.updateAriaAttributes();
+        }
+
+        bindEvents() {
+            // Navigation arrows
+            this.prevBtn.on('click', (e) => {
+                e.preventDefault();
+                this.prevSlide();
+            });
+
+            this.nextBtn.on('click', (e) => {
+                e.preventDefault();
+                this.nextSlide();
+            });
+
+            // Dots navigation
+            this.dots.on('click', (e) => {
+                e.preventDefault();
+                const slideIndex = parseInt($(e.target).data('slide'));
+                this.goToSlide(slideIndex);
+            });
+
+            // Pause autoplay on hover
+            if (this.autoplay) {
+                this.container.on('mouseenter', () => {
+                    this.pauseAutoplay();
+                });
+
+                this.container.on('mouseleave', () => {
+                    this.startAutoplay();
+                });
+            }
+
+            // Handle visibility change (pause when tab is not active)
+            $(document).on('visibilitychange', () => {
+                if (document.hidden) {
+                    this.pauseAutoplay();
+                } else if (this.autoplay) {
+                    this.startAutoplay();
+                }
+            });
+        }
+
+        bindKeyboardEvents() {
+            this.container.on('keydown', (e) => {
+                switch(e.which) {
+                    case 37: // Left arrow
+                        e.preventDefault();
+                        this.prevSlide();
+                        break;
+                    case 39: // Right arrow
+                        e.preventDefault();
+                        this.nextSlide();
+                        break;
+                    case 32: // Spacebar
+                        e.preventDefault();
+                        if (this.autoplay) {
+                            this.isPlaying() ? this.pauseAutoplay() : this.startAutoplay();
+                        }
+                        break;
+                }
+            });
+        }
+
+        bindTouchEvents() {
+            let startX = 0;
+            let startY = 0;
+            let endX = 0;
+            let endY = 0;
+
+            this.container.on('touchstart', (e) => {
+                startX = e.originalEvent.touches[0].clientX;
+                startY = e.originalEvent.touches[0].clientY;
+            });
+
+            this.container.on('touchend', (e) => {
+                endX = e.originalEvent.changedTouches[0].clientX;
+                endY = e.originalEvent.changedTouches[0].clientY;
+
+                const diffX = startX - endX;
+                const diffY = startY - endY;
+
+                // Only handle horizontal swipes (ignore vertical scrolling)
+                if (Math.abs(diffX) > Math.abs(diffY) && Math.abs(diffX) > 50) {
+                    if (diffX > 0) {
+                        this.nextSlide();
+                    } else {
+                        this.prevSlide();
+                    }
+                }
+            });
+        }
+
+        nextSlide() {
+            if (this.isTransitioning) return;
+            
+            const nextIndex = (this.currentSlide + 1) % this.totalSlides;
+            this.goToSlide(nextIndex);
+        }
+
+        prevSlide() {
+            if (this.isTransitioning) return;
+            
+            const prevIndex = this.currentSlide === 0 ? this.totalSlides - 1 : this.currentSlide - 1;
+            this.goToSlide(prevIndex);
+        }
+
+        goToSlide(index) {
+            if (this.isTransitioning || index === this.currentSlide || index < 0 || index >= this.totalSlides) {
+                return;
+            }
+
+            this.isTransitioning = true;
+
+            // Update current slide
+            const previousSlide = this.currentSlide;
+            this.currentSlide = index;
+
+            // Remove active class from all slides and dots
+            this.slides.removeClass('active');
+            this.dots.removeClass('active');
+
+            // Add active class to current slide and dot
+            this.slides.eq(this.currentSlide).addClass('active');
+            this.dots.eq(this.currentSlide).addClass('active');
+
+            // Update ARIA attributes
+            this.updateAriaAttributes();
+
+            // Trigger custom event
+            this.container.trigger('slideChanged', {
+                currentSlide: this.currentSlide,
+                previousSlide: previousSlide,
+                totalSlides: this.totalSlides
+            });
+
+            // Reset transition flag after animation completes
+            setTimeout(() => {
+                this.isTransitioning = false;
+            }, 800);
+
+            // Restart autoplay if it was running
+            if (this.autoplay && this.isPlaying()) {
+                this.startAutoplay();
+            }
+        }
+
+        startAutoplay() {
+            if (!this.autoplay || this.totalSlides <= 1) return;
+
+            this.pauseAutoplay();
+            this.autoplayTimer = setInterval(() => {
+                this.nextSlide();
+            }, this.autoplaySpeed);
+        }
+
+        pauseAutoplay() {
+            if (this.autoplayTimer) {
+                clearInterval(this.autoplayTimer);
+                this.autoplayTimer = null;
+            }
+        }
+
+        isPlaying() {
+            return this.autoplayTimer !== null;
+        }
+
+        updateAriaAttributes() {
+            // Update slide ARIA attributes
+            this.slides.each((index, slide) => {
+                const $slide = $(slide);
+                if (index === this.currentSlide) {
+                    $slide.attr('aria-hidden', 'false');
+                    $slide.find('a, button').attr('tabindex', '0');
+                } else {
+                    $slide.attr('aria-hidden', 'true');
+                    $slide.find('a, button').attr('tabindex', '-1');
+                }
+            });
+
+            // Update dot ARIA attributes
+            this.dots.each((index, dot) => {
+                const $dot = $(dot);
+                $dot.attr('aria-label', `Go to slide ${index + 1} of ${this.totalSlides}`);
+                $dot.attr('aria-pressed', index === this.currentSlide ? 'true' : 'false');
+            });
+
+            // Update arrow ARIA attributes
+            this.prevBtn.attr('aria-label', `Go to previous slide. Current slide ${this.currentSlide + 1} of ${this.totalSlides}`);
+            this.nextBtn.attr('aria-label', `Go to next slide. Current slide ${this.currentSlide + 1} of ${this.totalSlides}`);
+        }
+
+        // Public methods for external control
+        destroy() {
+            this.pauseAutoplay();
+            this.container.off();
+            this.prevBtn.off();
+            this.nextBtn.off();
+            this.dots.off();
+        }
+
+        getCurrentSlide() {
+            return this.currentSlide;
+        }
+
+        getTotalSlides() {
+            return this.totalSlides;
+        }
+    }
+
+    // Initialize sliders when DOM is ready
+    $(document).ready(function() {
+        $('.cryptotax-slider-container').each(function() {
+            new CryptoTaxSlider(this);
+        });
+    });
+
+    // Re-initialize sliders for dynamically added content (e.g., AJAX loaded content)
+    $(document).on('cryptotax:initSliders', function() {
+        $('.cryptotax-slider-container').each(function() {
+            if (!$(this).data('cryptotax-slider-initialized')) {
+                new CryptoTaxSlider(this);
+                $(this).data('cryptotax-slider-initialized', true);
+            }
+        });
+    });
+
+    // Expose the class globally for external use
+    window.CryptoTaxSlider = CryptoTaxSlider;
+
+})(jQuery);

--- a/cryptotax-theme/demo.html
+++ b/cryptotax-theme/demo.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CryptoTax Slider Demo</title>
+    
+    <!-- Include jQuery -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    
+    <!-- Include our CSS files -->
+    <link rel="stylesheet" href="assets/css/cryptotax-color-palette.css">
+    <link rel="stylesheet" href="assets/css/slider.css">
+    <link rel="stylesheet" href="style.css">
+    
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background-color: #f8f9fa;
+        }
+        
+        .demo-container {
+            max-width: 1200px;
+            margin: 2rem auto;
+            padding: 0 20px;
+        }
+        
+        .demo-header {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+        
+        .demo-header h1 {
+            background: var(--cryptotax-primary-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            font-size: 3rem;
+            margin-bottom: 1rem;
+        }
+        
+        .demo-header p {
+            font-size: 1.2rem;
+            color: var(--cryptotax-medium-gray);
+            max-width: 600px;
+            margin: 0 auto;
+        }
+        
+        .demo-section {
+            background: white;
+            border-radius: 12px;
+            padding: 2rem;
+            margin-bottom: 2rem;
+            box-shadow: var(--cryptotax-shadow);
+        }
+        
+        .demo-section h2 {
+            color: var(--cryptotax-deep-blue);
+            margin-bottom: 1rem;
+        }
+        
+        .features-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 2rem;
+            margin-top: 2rem;
+        }
+        
+        .feature-item {
+            text-align: center;
+            padding: 1.5rem;
+            border-radius: 8px;
+            background: linear-gradient(135deg, rgba(0, 67, 255, 0.05) 0%, rgba(163, 112, 241, 0.05) 100%);
+        }
+        
+        .feature-item h3 {
+            color: var(--cryptotax-deep-blue);
+            margin-bottom: 0.5rem;
+        }
+        
+        .controls {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            margin-top: 2rem;
+            justify-content: center;
+        }
+        
+        .control-btn {
+            background: var(--cryptotax-primary-gradient);
+            color: white;
+            border: none;
+            padding: 0.75rem 1.5rem;
+            border-radius: 25px;
+            cursor: pointer;
+            font-weight: 600;
+            transition: all 0.3s ease;
+        }
+        
+        .control-btn:hover {
+            background: var(--cryptotax-secondary-gradient);
+            transform: translateY(-2px);
+            box-shadow: var(--cryptotax-shadow-hover);
+        }
+    </style>
+</head>
+<body>
+    <div class="demo-container">
+        <div class="demo-header">
+            <h1>CryptoTax Slider</h1>
+            <p>A beautiful, responsive slider component with your brand colors and smooth animations.</p>
+        </div>
+
+        <!-- Main Slider Demo -->
+        <div class="demo-section">
+            <h2>Live Slider Demo</h2>
+            <div class="cryptotax-slider-container" id="demo-slider" 
+                 data-autoplay="true"
+                 data-autoplay-speed="5000">
+                <div class="cryptotax-slider">
+                    <div class="cryptotax-slide active">
+                        <div class="slide-background" style="background-image: url('https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1');">
+                            <div class="slide-overlay"></div>
+                        </div>
+                        <div class="slide-content">
+                            <div class="slide-content-inner">
+                                <h2 class="slide-title">Welcome to CryptoTax</h2>
+                                <p class="slide-description">Professional cryptocurrency tax solutions for individuals and businesses</p>
+                                <a href="#" class="slide-button btn cryptotax-gradient">Get Started Today</a>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="cryptotax-slide">
+                        <div class="slide-background" style="background-image: url('https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1');">
+                            <div class="slide-overlay"></div>
+                        </div>
+                        <div class="slide-content">
+                            <div class="slide-content-inner">
+                                <h2 class="slide-title">Accurate Tax Calculations</h2>
+                                <p class="slide-description">Advanced algorithms ensure precise cryptocurrency tax calculations</p>
+                                <a href="#" class="slide-button btn cryptotax-gradient">Learn More</a>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="cryptotax-slide">
+                        <div class="slide-background" style="background-image: url('https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1');">
+                            <div class="slide-overlay"></div>
+                        </div>
+                        <div class="slide-content">
+                            <div class="slide-content-inner">
+                                <h2 class="slide-title">Expert Support</h2>
+                                <p class="slide-description">24/7 support from cryptocurrency tax professionals</p>
+                                <a href="#" class="slide-button btn cryptotax-gradient">Contact Us</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="slider-arrows">
+                    <button class="slider-arrow slider-prev" aria-label="Previous slide">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M15 18L9 12L15 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                    </button>
+                    <button class="slider-arrow slider-next" aria-label="Next slide">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M9 18L15 12L9 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                    </button>
+                </div>
+                
+                <div class="slider-dots">
+                    <button class="slider-dot active" data-slide="0"></button>
+                    <button class="slider-dot" data-slide="1"></button>
+                    <button class="slider-dot" data-slide="2"></button>
+                </div>
+            </div>
+            
+            <div class="controls">
+                <button class="control-btn" onclick="toggleAutoplay()">Toggle Autoplay</button>
+                <button class="control-btn" onclick="goToSlide(0)">Slide 1</button>
+                <button class="control-btn" onclick="goToSlide(1)">Slide 2</button>
+                <button class="control-btn" onclick="goToSlide(2)">Slide 3</button>
+            </div>
+        </div>
+
+        <!-- Features Section -->
+        <div class="demo-section">
+            <h2>Slider Features</h2>
+            <div class="features-grid">
+                <div class="feature-item">
+                    <h3>🎨 Brand Colors</h3>
+                    <p>Uses your CryptoTax brand color palette</p>
+                </div>
+                <div class="feature-item">
+                    <h3>📱 Responsive</h3>
+                    <p>Works perfectly on all devices</p>
+                </div>
+                <div class="feature-item">
+                    <h3>⚡ Smooth Animations</h3>
+                    <p>Beautiful transitions and effects</p>
+                </div>
+                <div class="feature-item">
+                    <h3>♿ Accessible</h3>
+                    <p>Keyboard navigation and ARIA support</p>
+                </div>
+                <div class="feature-item">
+                    <h3>👆 Touch Support</h3>
+                    <p>Swipe gestures on mobile devices</p>
+                </div>
+                <div class="feature-item">
+                    <h3>🔧 Gutenberg Ready</h3>
+                    <p>Easy to use in the block editor</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Include our JavaScript -->
+    <script src="assets/js/slider.js"></script>
+    
+    <script>
+        // Demo control functions
+        let demoSlider;
+        
+        $(document).ready(function() {
+            // Get the slider instance
+            setTimeout(() => {
+                demoSlider = $('#demo-slider').data('cryptotax-slider-initialized');
+            }, 100);
+        });
+        
+        function toggleAutoplay() {
+            const container = $('#demo-slider');
+            const currentAutoplay = container.data('autoplay');
+            container.data('autoplay', !currentAutoplay);
+            
+            // Reinitialize slider with new settings
+            location.reload();
+        }
+        
+        function goToSlide(index) {
+            $('#demo-slider').trigger('cryptotax:goToSlide', [index]);
+        }
+        
+        // Listen for slide changes
+        $('#demo-slider').on('slideChanged', function(e, data) {
+            console.log('Slide changed to:', data.currentSlide + 1);
+        });
+    </script>
+</body>
+</html>

--- a/cryptotax-theme/front-page.php
+++ b/cryptotax-theme/front-page.php
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+    <header id="masthead" class="site-header">
+        <div class="container">
+            <div class="site-branding">
+                <?php
+                if (has_custom_logo()) {
+                    the_custom_logo();
+                } else {
+                    ?>
+                    <h1 class="site-title">
+                        <a href="<?php echo esc_url(home_url('/')); ?>" rel="home">
+                            <?php bloginfo('name'); ?>
+                        </a>
+                    </h1>
+                    <?php
+                }
+                ?>
+            </div>
+
+            <nav id="site-navigation" class="main-navigation">
+                <?php
+                wp_nav_menu(array(
+                    'theme_location' => 'primary',
+                    'menu_id' => 'primary-menu',
+                    'fallback_cb' => false,
+                ));
+                ?>
+            </nav>
+        </div>
+    </header>
+
+    <!-- Demo Slider Section -->
+    <section class="hero-section">
+        <div class="container-fluid">
+            <?php
+            // Display demo slider with the provided image
+            echo do_shortcode('[cryptotax_slider]');
+            
+            // Or render the block directly
+            echo cryptotax_render_slider_block(array(
+                'slides' => array(
+                    array(
+                        'image' => 'https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1',
+                        'title' => 'Welcome to CryptoTax',
+                        'description' => 'Professional cryptocurrency tax solutions for individuals and businesses',
+                        'buttonText' => 'Get Started Today',
+                        'buttonUrl' => '#services'
+                    ),
+                    array(
+                        'image' => 'https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1',
+                        'title' => 'Accurate Tax Calculations',
+                        'description' => 'Advanced algorithms ensure precise cryptocurrency tax calculations',
+                        'buttonText' => 'Learn More',
+                        'buttonUrl' => '#features'
+                    ),
+                    array(
+                        'image' => 'https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1',
+                        'title' => 'Expert Support',
+                        'description' => '24/7 support from cryptocurrency tax professionals',
+                        'buttonText' => 'Contact Us',
+                        'buttonUrl' => '#contact'
+                    )
+                ),
+                'autoplay' => true,
+                'autoplaySpeed' => 6000,
+                'showDots' => true,
+                'showArrows' => true
+            ));
+            ?>
+        </div>
+    </section>
+
+    <main id="primary" class="site-main">
+        <div class="container">
+            <?php
+            if (have_posts()) :
+                while (have_posts()) :
+                    the_post();
+                    ?>
+                    <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+                        <div class="entry-content">
+                            <?php
+                            the_content();
+                            
+                            wp_link_pages(array(
+                                'before' => '<div class="page-links">' . esc_html__('Pages:', 'cryptotax'),
+                                'after'  => '</div>',
+                            ));
+                            ?>
+                        </div>
+                    </article>
+                    <?php
+                endwhile;
+            endif;
+            ?>
+            
+            <!-- Additional content sections -->
+            <section id="services" class="services-section">
+                <div class="container">
+                    <h2>Our Services</h2>
+                    <div class="services-grid">
+                        <div class="service-item">
+                            <h3>Individual Tax Filing</h3>
+                            <p>Comprehensive cryptocurrency tax solutions for individual investors.</p>
+                        </div>
+                        <div class="service-item">
+                            <h3>Business Solutions</h3>
+                            <p>Enterprise-grade crypto tax management for businesses and institutions.</p>
+                        </div>
+                        <div class="service-item">
+                            <h3>Tax Planning</h3>
+                            <p>Strategic tax planning to optimize your cryptocurrency investments.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <footer id="colophon" class="site-footer">
+        <div class="container">
+            <div class="site-info">
+                <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?>. All rights reserved.</p>
+                <?php
+                wp_nav_menu(array(
+                    'theme_location' => 'footer',
+                    'menu_id' => 'footer-menu',
+                    'fallback_cb' => false,
+                ));
+                ?>
+            </div>
+        </div>
+    </footer>
+</div>
+
+<style>
+.container { max-width: 1200px; margin: 0 auto; padding: 0 20px; }
+.container-fluid { width: 100%; padding: 0; }
+.hero-section { margin-bottom: 4rem; }
+.services-section { padding: 4rem 0; background: #f8f9fa; }
+.services-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem; margin-top: 2rem; }
+.service-item { background: white; padding: 2rem; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+.service-item h3 { color: #0043FF; margin-bottom: 1rem; }
+</style>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/cryptotax-theme/functions.php
+++ b/cryptotax-theme/functions.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * CryptoTax Theme functions and definitions
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Theme setup
+ */
+function cryptotax_theme_setup() {
+    // Add theme support for various features
+    add_theme_support('post-thumbnails');
+    add_theme_support('html5', array(
+        'search-form',
+        'comment-form',
+        'comment-list',
+        'gallery',
+        'caption',
+    ));
+    add_theme_support('title-tag');
+    add_theme_support('custom-logo');
+    
+    // Add support for Gutenberg wide and full alignments
+    add_theme_support('align-wide');
+    
+    // Add support for editor styles
+    add_theme_support('editor-styles');
+    add_editor_style('assets/css/editor-style.css');
+    
+    // Register navigation menus
+    register_nav_menus(array(
+        'primary' => __('Primary Menu', 'cryptotax'),
+        'footer' => __('Footer Menu', 'cryptotax'),
+    ));
+}
+add_action('after_setup_theme', 'cryptotax_theme_setup');
+
+/**
+ * Enqueue scripts and styles
+ */
+function cryptotax_scripts() {
+    // Enqueue theme stylesheet
+    wp_enqueue_style('cryptotax-style', get_stylesheet_uri(), array(), wp_get_theme()->get('Version'));
+    
+    // Enqueue custom slider styles
+    wp_enqueue_style('cryptotax-slider', get_template_directory_uri() . '/assets/css/slider.css', array(), wp_get_theme()->get('Version'));
+    
+    // Enqueue custom slider script
+    wp_enqueue_script('cryptotax-slider', get_template_directory_uri() . '/assets/js/slider.js', array('jquery'), wp_get_theme()->get('Version'), true);
+}
+add_action('wp_enqueue_scripts', 'cryptotax_scripts');
+
+/**
+ * Enqueue block editor assets
+ */
+function cryptotax_block_editor_assets() {
+    // Enqueue block editor script
+    wp_enqueue_script(
+        'cryptotax-blocks',
+        get_template_directory_uri() . '/assets/js/blocks.js',
+        array('wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'),
+        wp_get_theme()->get('Version')
+    );
+    
+    // Enqueue block editor styles
+    wp_enqueue_style(
+        'cryptotax-blocks-editor',
+        get_template_directory_uri() . '/assets/css/blocks-editor.css',
+        array('wp-edit-blocks'),
+        wp_get_theme()->get('Version')
+    );
+}
+add_action('enqueue_block_editor_assets', 'cryptotax_block_editor_assets');
+
+/**
+ * Register custom blocks
+ */
+function cryptotax_register_blocks() {
+    // Register the slider block
+    register_block_type('cryptotax/slider', array(
+        'editor_script' => 'cryptotax-blocks',
+        'editor_style' => 'cryptotax-blocks-editor',
+        'style' => 'cryptotax-slider',
+        'render_callback' => 'cryptotax_render_slider_block',
+        'attributes' => array(
+            'slides' => array(
+                'type' => 'array',
+                'default' => array(
+                    array(
+                        'image' => 'https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1',
+                        'title' => 'Welcome to CryptoTax',
+                        'description' => 'Professional cryptocurrency tax solutions',
+                        'buttonText' => 'Get Started',
+                        'buttonUrl' => '#'
+                    )
+                )
+            ),
+            'autoplay' => array(
+                'type' => 'boolean',
+                'default' => true
+            ),
+            'autoplaySpeed' => array(
+                'type' => 'number',
+                'default' => 5000
+            ),
+            'showDots' => array(
+                'type' => 'boolean',
+                'default' => true
+            ),
+            'showArrows' => array(
+                'type' => 'boolean',
+                'default' => true
+            )
+        )
+    ));
+}
+add_action('init', 'cryptotax_register_blocks');
+
+/**
+ * Render callback for the slider block
+ */
+function cryptotax_render_slider_block($attributes) {
+    $slides = $attributes['slides'] ?? array();
+    $autoplay = $attributes['autoplay'] ?? true;
+    $autoplaySpeed = $attributes['autoplaySpeed'] ?? 5000;
+    $showDots = $attributes['showDots'] ?? true;
+    $showArrows = $attributes['showArrows'] ?? true;
+    
+    if (empty($slides)) {
+        return '';
+    }
+    
+    $slider_id = 'cryptotax-slider-' . uniqid();
+    
+    ob_start();
+    ?>
+    <div class="cryptotax-slider-container" id="<?php echo esc_attr($slider_id); ?>" 
+         data-autoplay="<?php echo $autoplay ? 'true' : 'false'; ?>"
+         data-autoplay-speed="<?php echo esc_attr($autoplaySpeed); ?>">
+        <div class="cryptotax-slider">
+            <?php foreach ($slides as $index => $slide): ?>
+                <div class="cryptotax-slide <?php echo $index === 0 ? 'active' : ''; ?>">
+                    <?php if (!empty($slide['image'])): ?>
+                        <div class="slide-background" style="background-image: url('<?php echo esc_url($slide['image']); ?>');">
+                            <div class="slide-overlay"></div>
+                        </div>
+                    <?php endif; ?>
+                    <div class="slide-content">
+                        <div class="slide-content-inner">
+                            <?php if (!empty($slide['title'])): ?>
+                                <h2 class="slide-title"><?php echo esc_html($slide['title']); ?></h2>
+                            <?php endif; ?>
+                            <?php if (!empty($slide['description'])): ?>
+                                <p class="slide-description"><?php echo esc_html($slide['description']); ?></p>
+                            <?php endif; ?>
+                            <?php if (!empty($slide['buttonText']) && !empty($slide['buttonUrl'])): ?>
+                                <a href="<?php echo esc_url($slide['buttonUrl']); ?>" class="slide-button btn cryptotax-gradient">
+                                    <?php echo esc_html($slide['buttonText']); ?>
+                                </a>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+        
+        <?php if ($showArrows && count($slides) > 1): ?>
+            <div class="slider-arrows">
+                <button class="slider-arrow slider-prev" aria-label="Previous slide">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M15 18L9 12L15 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                </button>
+                <button class="slider-arrow slider-next" aria-label="Next slide">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M9 18L15 12L9 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                </button>
+            </div>
+        <?php endif; ?>
+        
+        <?php if ($showDots && count($slides) > 1): ?>
+            <div class="slider-dots">
+                <?php for ($i = 0; $i < count($slides); $i++): ?>
+                    <button class="slider-dot <?php echo $i === 0 ? 'active' : ''; ?>" data-slide="<?php echo $i; ?>"></button>
+                <?php endfor; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+
+/**
+ * Add custom block category
+ */
+function cryptotax_block_categories($categories) {
+    return array_merge(
+        $categories,
+        array(
+            array(
+                'slug' => 'cryptotax',
+                'title' => __('CryptoTax Blocks', 'cryptotax'),
+                'icon' => 'slides',
+            ),
+        )
+    );
+}
+add_filter('block_categories_all', 'cryptotax_block_categories', 10, 2);
+
+/**
+ * Add shortcode for the slider
+ */
+function cryptotax_slider_shortcode($atts) {
+    $atts = shortcode_atts(array(
+        'autoplay' => true,
+        'autoplay_speed' => 5000,
+        'show_dots' => true,
+        'show_arrows' => true,
+    ), $atts);
+    
+    $attributes = array(
+        'slides' => array(
+            array(
+                'image' => 'https://i0.wp.com/blissful-euler.23-22-90-233.plesk.page/wp-content/uploads/2021/08/bg_video.jpg?fit=1020%2C584&ssl=1',
+                'title' => 'Welcome to CryptoTax',
+                'description' => 'Professional cryptocurrency tax solutions',
+                'buttonText' => 'Get Started',
+                'buttonUrl' => '#'
+            )
+        ),
+        'autoplay' => filter_var($atts['autoplay'], FILTER_VALIDATE_BOOLEAN),
+        'autoplaySpeed' => intval($atts['autoplay_speed']),
+        'showDots' => filter_var($atts['show_dots'], FILTER_VALIDATE_BOOLEAN),
+        'showArrows' => filter_var($atts['show_arrows'], FILTER_VALIDATE_BOOLEAN)
+    );
+    
+    return cryptotax_render_slider_block($attributes);
+}
+add_shortcode('cryptotax_slider', 'cryptotax_slider_shortcode');

--- a/cryptotax-theme/index.php
+++ b/cryptotax-theme/index.php
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+    <header id="masthead" class="site-header">
+        <div class="site-branding">
+            <?php
+            if (has_custom_logo()) {
+                the_custom_logo();
+            } else {
+                ?>
+                <h1 class="site-title">
+                    <a href="<?php echo esc_url(home_url('/')); ?>" rel="home">
+                        <?php bloginfo('name'); ?>
+                    </a>
+                </h1>
+                <?php
+            }
+            ?>
+        </div>
+
+        <nav id="site-navigation" class="main-navigation">
+            <?php
+            wp_nav_menu(array(
+                'theme_location' => 'primary',
+                'menu_id' => 'primary-menu',
+                'fallback_cb' => false,
+            ));
+            ?>
+        </nav>
+    </header>
+
+    <main id="primary" class="site-main">
+        <?php
+        if (have_posts()) :
+            while (have_posts()) :
+                the_post();
+                ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+                    <header class="entry-header">
+                        <?php the_title('<h1 class="entry-title">', '</h1>'); ?>
+                    </header>
+
+                    <div class="entry-content">
+                        <?php
+                        the_content();
+                        
+                        wp_link_pages(array(
+                            'before' => '<div class="page-links">' . esc_html__('Pages:', 'cryptotax'),
+                            'after'  => '</div>',
+                        ));
+                        ?>
+                    </div>
+                </article>
+                <?php
+            endwhile;
+        else :
+            ?>
+            <section class="no-results not-found">
+                <header class="page-header">
+                    <h1 class="page-title"><?php esc_html_e('Nothing here', 'cryptotax'); ?></h1>
+                </header>
+                <div class="page-content">
+                    <p><?php esc_html_e('It looks like nothing was found at this location.', 'cryptotax'); ?></p>
+                </div>
+            </section>
+            <?php
+        endif;
+        ?>
+    </main>
+
+    <footer id="colophon" class="site-footer">
+        <div class="site-info">
+            <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?>. All rights reserved.</p>
+        </div>
+    </footer>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/cryptotax-theme/style.css
+++ b/cryptotax-theme/style.css
@@ -1,0 +1,147 @@
+/*
+Theme Name: CryptoTax Theme
+Description: A custom WordPress theme for CryptoTax with branded colors and custom slider block
+Version: 1.0
+Author: CryptoTax Team
+*/
+
+/* CryptoTax Custom Colors - Based on Logo */
+
+/* Import the color palette */
+@import url('./assets/css/cryptotax-color-palette.css');
+
+/* Override theme colors with CryptoTax brand colors */
+:root {
+  /* Primary Colors */
+  --paletteColor1: #0043FF; /* Deep Blue */
+  --paletteColor2: #A370F1; /* Purple */
+  --paletteColor3: #4BF2E6; /* Cyan */
+  --paletteColor4: #0065FF; /* Bright Blue */
+  --paletteColor5: #EEEEEE; /* Light Gray */
+  --paletteColor6: #777777; /* Medium Gray */
+  --paletteColor7: #333333; /* Dark Gray */
+  --paletteColor8: #FFFFFF; /* White */
+}
+
+/* Header and Navigation */
+.site-header {
+  background: linear-gradient(135deg, #0043FF 0%, #A370F1 100%);
+}
+
+.main-navigation a {
+  color: #EEEEEE;
+}
+
+.main-navigation a:hover {
+  color: #4BF2E6;
+}
+
+/* Buttons */
+.wp-block-button__link,
+.button,
+.btn {
+  background: linear-gradient(135deg, #0043FF 0%, #A370F1 100%);
+  color: #FFFFFF;
+  border: none;
+}
+
+.wp-block-button__link:hover,
+.button:hover,
+.btn:hover {
+  background: linear-gradient(135deg, #4BF2E6 0%, #0065FF 100%);
+  color: #FFFFFF;
+}
+
+/* Secondary Buttons */
+.wp-block-button.is-style-outline .wp-block-button__link {
+  border: 2px solid #0043FF;
+  color: #0043FF;
+  background: transparent;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link:hover {
+  background: #0043FF;
+  color: #FFFFFF;
+}
+
+/* Links */
+a {
+  color: #0065FF;
+}
+
+a:hover {
+  color: #0043FF;
+}
+
+/* Headings */
+h1, h2, h3, h4, h5, h6 {
+  color: #333333;
+}
+
+/* Text */
+body {
+  color: #333333;
+}
+
+/* Accent Elements */
+.accent-color {
+  color: #4BF2E6;
+}
+
+.accent-bg {
+  background-color: #4BF2E6;
+}
+
+/* Footer */
+.site-footer {
+  background-color: #333333;
+  color: #EEEEEE;
+}
+
+.site-footer a {
+  color: #4BF2E6;
+}
+
+.site-footer a:hover {
+  color: #FFFFFF;
+}
+
+/* Cards and Content Blocks */
+.wp-block-group,
+.wp-block-columns {
+  border-color: #E9ECEF;
+}
+
+/* Form Elements */
+input[type="text"],
+input[type="email"],
+input[type="password"],
+textarea,
+select {
+  border-color: #CED4DA;
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus,
+textarea:focus,
+select:focus {
+  border-color: #0043FF;
+  box-shadow: 0 0 0 2px rgba(0, 67, 255, 0.2);
+}
+
+/* Custom Brand Elements */
+.cryptotax-gradient {
+  background: linear-gradient(135deg, #0043FF 0%, #A370F1 100%);
+}
+
+.cryptotax-gradient-cyan {
+  background: linear-gradient(135deg, #4BF2E6 0%, #0065FF 100%);
+}
+
+.cryptotax-text-gradient {
+  background: linear-gradient(135deg, #0043FF 0%, #A370F1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}


### PR DESCRIPTION
Add a new CryptoTax WordPress theme with a custom, branded slider block to fulfill the user's request for website pages and a block editor slider.

---
<a href="https://cursor.com/background-agent?bcId=bc-13b994aa-6a8d-4a12-a4b7-a74c674526ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13b994aa-6a8d-4a12-a4b7-a74c674526ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

